### PR TITLE
Remove newsletter from mobile sidebar

### DIFF
--- a/app/components/modules/sidebar-new/Sidebar.tsx
+++ b/app/components/modules/sidebar-new/Sidebar.tsx
@@ -232,6 +232,12 @@ const ConnectedItem = styled.a`
   }
 `;
 
+const NewsletterItem = styled(ConnectedItem)`
+  @media (max-width: ${LAYOUT_CONSTANTS.MOBILE_BREAKPOINT}px) {
+    display: none;
+  }
+`;
+
 const ConnectedIcon = styled.span`
   font-size: 1.25rem;
   line-height: 1;
@@ -702,10 +708,10 @@ export const Sidebar: React.FC = () => {
       <StayConnected>
         <ConnectedTitle>Stay Connected</ConnectedTitle>
         <ConnectedList>
-          <ConnectedItem href="mailto:nasirmovlamov@gmail.com">
+          <NewsletterItem href="mailto:nasirmovlamov@gmail.com">
             <ConnectedIcon>📧</ConnectedIcon>
             Email Newsletter
-          </ConnectedItem>
+          </NewsletterItem>
           <ConnectedItem
             href="https://github.com/nasirmovlamov"
             target="_blank"


### PR DESCRIPTION
Remove the newsletter section from the mobile sidebar.

The newsletter link is now wrapped in a `NewsletterItem` styled-component that sets `display: none` for viewports below `LAYOUT_CONSTANTS.MOBILE_BREAKPOINT`, ensuring it only disappears on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6b33e06-e7a4-4d4b-be25-7acc0c23b62d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6b33e06-e7a4-4d4b-be25-7acc0c23b62d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

